### PR TITLE
Update to Emscripten 1.39.4.4

### DIFF
--- a/README.Samsung.md
+++ b/README.Samsung.md
@@ -28,7 +28,6 @@ cmake -DCMAKE_TOOLCHAIN_FILE=<YOUR EMSCRIPTEN INSTALLATION_DIR>/cmake/Modules/Pl
 ninja
 
 mkdir widget/
-cd widget/
 cmake --install . --prefix .
 ```
 

--- a/notes.txt
+++ b/notes.txt
@@ -1,0 +1,10 @@
+git submodule update --init --recursive
+mkdir build; cd build
+cmake -DCMAKE_TOOLCHAIN_FILE=C:\Users\samsung\Programs\emscripten-1.39.4.3-windows64\emscripten-release-bundle\emsdk\fastcomp\emscripten\cmake\Modules\Platform\Emscripten.cmake -G Ninja ..
+C:\tizen-studio\tools\ide\bin\tizen.bat run -p MoonLightS.MoonlightWasm 
+C:\tizen-studio\tools\ide\bin\tizen.bat install -n MoonlightWasm.wgt 
+C:\tizen-studio\tools\ide\bin\tizen.bat package -t wgt -- . 
+cmake --install . --prefix . 
+cmake -DCMAKE_TOOLCHAIN_FILE=C:\Users\samsung\Programs\emscripten-1.39.4.4-windows64\emscripten-release-bundle\emsdk\fastcomp\emscripten\cmake\Modules\Platform\Emscripten.cmake -G Ninja .. 
+emsdk activate latest-fastcomp 
+ninja 

--- a/wasm/main.cpp
+++ b/wasm/main.cpp
@@ -201,7 +201,7 @@ MessageResult MoonlightInstance::StartStream(
   m_StreamConfig.streamingRemotely = STREAM_CFG_AUTO;
   m_StreamConfig.packetSize = 1392;
   m_StreamConfig.supportsHevc = true;
-  m_StreamConfig.enableHdr = true;
+  //m_StreamConfig.enableHdr = true;
 
   // Load the rikey and rikeyid into the stream configuration
   HexStringToBytes(rikey.c_str(), m_StreamConfig.remoteInputAesKey);

--- a/wasm/wasmplayer.cpp
+++ b/wasm/wasmplayer.cpp
@@ -12,15 +12,15 @@
 #include "samsung/wasm/elementary_media_packet.h"
 #include "samsung/wasm/elementary_video_track_config.h"
 #include "samsung/html/html_media_element_listener.h"
+#include "samsung/wasm/operation_result.h"
 
 #define INITIAL_DECODE_BUFFER_LEN 128 * 1024
 
 using std::chrono_literals::operator""s;
 using std::chrono_literals::operator""ms;
 using EmssReadyState = samsung::wasm::ElementaryMediaStreamSource::ReadyState;
-using EmssAsyncResult
-    = samsung::wasm::ElementaryMediaStreamSource::AsyncResult;
-using HTMLAsyncResult = samsung::html::HTMLMediaElement::AsyncResult;
+using EmssAsyncResult = samsung::wasm::OperationResult;
+using HTMLAsyncResult = samsung::wasm::OperationResult;
 using TimeStamp = samsung::wasm::Seconds;
 
 static constexpr TimeStamp kFrameTimeMargin = 0.5ms;


### PR DESCRIPTION
# Update to Emscripten 1.39.4.4

https://developer.samsung.com/smarttv/develop/extension-libraries/webassembly/download.html

As of today, the most recent version of Emscripten is 1.39.4.4.  There are some changes to the Open and Play argument data types and compiling the code with Emscripten 1.39.4.4. causes compilation errors.  I have fixed those compilation errors in the least invasive way I could come up with.

@moonlight-stream
